### PR TITLE
Fix dark mode text colors

### DIFF
--- a/public/themes/themes.css
+++ b/public/themes/themes.css
@@ -2,7 +2,6 @@
 @layer base {
   :root {
     --color-text-base: 0, 0, 0;
-    --color-text-muted: 120, 120, 120;
     --color-text-muted: 50, 50, 50;
     --color-text-inverted: 255, 255, 255;
     --color-fill: 245, 245, 245; /* lignes et contours */
@@ -27,6 +26,6 @@
     --color-button-accent-hover: 48, 115, 48; 
     --color-button-muted: 26, 26, 26; /* bg black */
     --color-text-contact-icons: 255, 115, 48; /* orange */
-    --color-text-contact-icons-inverted: 20, 20, 20; /* ligne des svg */
+    --color-text-contact-icons-inverted: 255, 255, 255; /* ligne des svg */
   }
 }

--- a/src/components/Dialog.astro
+++ b/src/components/Dialog.astro
@@ -7,7 +7,7 @@ const currentYear = new Date().getFullYear();
 <div x-data="{modalIsOpen: false}">
 
     <button x-on:click="modalIsOpen = true" type="button" class="group flex items-center space-x-1 text-xs">
-        <span class="px:3 hover:text-skin-contact flex gap-1 underline decoration-dotted underline-offset-4 transition group-hover:underline-offset-4">Mentions & Confidentialité</span>
+        <span class="px:3 hover:text-skin-contact flex gap-1 underline decoration-dotted underline-offset-4 transition group-hover:underline-offset-4 text-skin-base">Mentions & Confidentialité</span>
     </button>
   
     <div x-cloak x-show="modalIsOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="modalIsOpen" x-on:keydown.esc.window="modalIsOpen = false" x-on:click.self="modalIsOpen = false" class="fixed inset-0 z-30 flex items-end justify-center bg-black/20 p-4 pb-8 backdrop-blur-md sm:items-center lg:p-8">
@@ -58,7 +58,7 @@ const currentYear = new Date().getFullYear();
             <!-- Dialog Footer -->
               <div class="flex flex-col-reverse justify-between gap-2 border-t border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 p-4 sm:flex-row sm:items-center md:justify-end">
                   <p class="group flex items-center space-x-1 text-xs">
-                    <span class="hover:text-skin-contact flex gap-1 underline decoration-dotted underline-offset-4 transition group-hover:underline-offset-4">
+                    <span class="hover:text-skin-contact flex gap-1 underline decoration-dotted underline-offset-4 transition group-hover:underline-offset-4 text-skin-base">
                       {currentYear} © SC
                     </span>
                   </p>

--- a/src/components/sections/Tail.astro
+++ b/src/components/sections/Tail.astro
@@ -15,10 +15,10 @@ const currentYear = new Date().getFullYear();
 	   aria-label={`Voir le profil ${gitHub} de ${name}`}
 	   title={`Voir le profil ${gitHub} de ${name}`}
 	   target="_blank" 
-	   class="group flex items-center space-x-1 text-xs">
-		<span class="hover:text-skin-contact flex gap-1 underline decoration-dotted underline-offset-4 transition group-hover:underline-offset-4">
-			2021 - {currentYear} © SC
-		</span>
+           class="group flex items-center space-x-1 text-xs">
+                <span class="hover:text-skin-contact flex gap-1 underline decoration-dotted underline-offset-4 transition group-hover:underline-offset-4 text-skin-base">
+                        2021 - {currentYear} © SC
+                </span>
 	</a>
 	<Dialog />
 </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -74,7 +74,7 @@ const { image, summary, url, theme } = basics;
 				.catch(error => console.error("Erreur chargement tracking.json :", error));
 		</script>
 	</head>
-	<body data-theme={theme} class="bg-white dark:bg-gray-900">
+        <body data-theme={theme} class="bg-white text-skin-base dark:bg-gray-900">
 		<div class="absolute top-0 -z-10 h-full w-full print:hidden">
 			<div class="bg-skin-hue/10 absolute bottom-auto left-[20%] right-auto top-0 h-[200px] w-[200px] -translate-x-[30%] translate-y-[20%] rounded-full blur-[80px] invert-0 dark:bg-white/5"></div>
 		</div>


### PR DESCRIPTION
## Summary
- ensure body text adapts to the active theme
- remove duplicate theme variable and fix icon color in dark mode
- apply text color to some unstyled spans

## Testing
- `pnpm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868b7cec8ac832a85e08f29afb3c921