### PR TITLE
Add tooltip to skills list

### DIFF
--- a/src/components/sections/Skills.astro
+++ b/src/components/sections/Skills.astro
@@ -41,31 +41,56 @@ import { skills } from "@cv";
 ---
 
 <Section className={Astro.props.className} title="Technologies">
-	<ul class="[&>li>svg]:text-skin-hue inline-flex flex-wrap gap-6 [&>li>svg]:size-5 [&>li]:text-sm">
-		{
-			skills.map(({ name }) => {
-				// const iconName = name === "Next.js" ? "Next" : name;
-				// const Icon = SKILLS_ICONS[iconName];
+        <ul class="[&>li>svg]:text-skin-hue inline-flex flex-wrap gap-6 [&>li>svg]:size-5 [&>li]:text-sm">
+                {
+                        skills.map(({ name, level, keywords }) => {
+                                // const iconName = name === "Next.js" ? "Next" : name;
+                                // const Icon = SKILLS_ICONS[iconName];
 
-				return (
-					<li 
-						class="
-						bg-skin-hue/100 border-skin-hue/20 text-skin-inverted 
-						border-skin-hue/100 
-						bg-skin-button-accent/80 
-						flex items-center gap-1 
-						rounded-md 
-						px-2 py-0.5 
-						text-xs 
-						text-skin-base 
-						print:border-none print:bg-transparent print:p-0 print:text-zinc-800">
-						<!-- je commente l'affichage des icons parce que je les ai pas tous... 
-						  {Icon && <Icon />} 
-						-->
-						<span>{name}</span>
-					</li>
-				);
-			})
-		}
-	</ul>
+                                return (
+                                        <div
+                                                x-data="{ open: false }"
+                                                @mouseenter="open = true"
+                                                @mouseleave="open = false"
+                                                class="relative"
+                                        >
+                                                <li
+                                                        class="
+                                                        bg-skin-hue/100 border-skin-hue/20 text-skin-inverted
+                                                        border-skin-hue/100
+                                                        bg-skin-button-accent/80
+                                                        flex items-center gap-1
+                                                        rounded-md
+                                                        px-2 py-0.5
+                                                        text-xs
+                                                        text-skin-base
+                                                        print:border-none print:bg-transparent print:p-0 print:text-zinc-800">
+                                                        <!-- je commente l'affichage des icons parce que je les ai pas tous...
+                                                          {Icon && <Icon />}
+                                                        -->
+                                                        <span>{name}</span>
+                                                </li>
+                                                <div
+                                                        x-show="open"
+                                                        x-cloak
+                                                        class="tooltip absolute left-1/2 top-full z-10 mt-1 w-max -translate-x-1/2 rounded bg-white dark:bg-gray-800 p-2 text-xs shadow"
+                                                >
+                                                        <div class="font-semibold">{level}</div>
+                                                        <ul class="mt-1 flex flex-wrap gap-1">
+                                                                {keywords?.map(keyword => (
+                                                                        <li class="rounded bg-skin-button-muted px-1 dark:bg-gray-700">{keyword}</li>
+                                                                ))}
+                                                        </ul>
+                                                </div>
+                                        </div>
+                                );
+                        })
+                }
+        </ul>
 </Section>
+
+<style>
+        .tooltip {
+                @apply text-skin-base dark:text-skin-inverted;
+        }
+</style>


### PR DESCRIPTION
## Summary
- enhance Skills section: show tooltip with level and keywords
- style tooltip for light/dark themes

## Testing
- `pnpm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868be917f4c832aa8de8e7d458c4b76