### PR TITLE
Add bilingual support with automatic translation

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,0 +1,32 @@
+name: Translate CV
+
+on:
+  push:
+    paths:
+      - 'cv.json'
+  workflow_dispatch:
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm run translate-cv
+        env:
+          TRANSLATION_API_URL: ${{ secrets.TRANSLATION_API_URL }}
+          TRANSLATION_API_KEY: ${{ secrets.TRANSLATION_API_KEY }}
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add cv.en.json
+          if git diff --cached --quiet; then echo "No changes"; else git commit -m 'Update English CV translation'; git push; fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cv.en.json
+++ b/cv.en.json
@@ -1,0 +1,642 @@
+{
+  "basics": {
+    "name": "Simon Chabrier",
+    "label": "Développeur Full Stack",
+    "image": "./avatar_254.webp",
+    "imagesmall": "./avatar_128.webp",
+    "email": "simonchabrier@gmail.com",
+    "phone": "06 63 24 45 87",
+    "url": "https://www.linkedin.com/in/simon-chabrier/",
+    "summary": "Développeur Full Stack passionné, Je conçois des applications web performantes, sécurisées et éco-responsables en respectant les normes d'accessibilité et le RGPD. Formé à l'Agilité, j'apprécie le travail en équipe, le partage de connaissances et relever des nouveaux challenges métiers en veillant toujours au respect des coûts et des délais. Mon code est systématiquement documenté, testé et déployé en continu, avec une gestion maîtrisée de la dette technique et des refactorisations régulières. À titre personnel, je déploie et optimise mes projets de recherche sur mon home serveur Ubuntu, pour affiner en continu mes compétences DevOps...",
+    "theme": "default",
+    "location": {
+      "address": "168 Quai Baudin",
+      "postalCode": "47000",
+      "city": "Agen",
+      "countryCode": "FR",
+      "region": "France"
+    },
+    "profiles": [
+      {
+        "network": "LinkedIn",
+        "username": "Simon Chabrier",
+        "url": "https://www.linkedin.com/in/simon-chabrier/"
+      },
+      {
+        "network": "GitHub",
+        "username": "Simon Chabrier",
+        "url": "https://github.com/SimonChabrier"
+      }
+    ]
+  },
+  "work": [
+    {
+      "name": "Libre Sens",
+      "position": "Développeur Full Stack - CDI",
+      "location_type": "Sur site",
+      "location": "Agen, France",
+      "url": "https://libresens.com/",
+      "startDate": "01/02/24",
+      "endDate": null,
+      "summary": "Concevoir, développer et documenter des applications web.",
+      "responsibilities": [
+        "En collaboration avec le Product Owner et l’équipe, autour de l’étude du cahier des charges, j'établis les documents de conception des applications et/ou fonctionnalités qui me sont assignés en veillant à analyser les risques et à détailler/planifier les différentes phases de livraison du MVP jusqu'au produit fini."
+      ],
+      "achievements": [
+        "En charge de la refonte du CMS de l'entreprise.",
+        "Appplication Web de gestion et de suivi d'autonomie des résidents en EHPAD.",
+        "Application Web de type CRM pour une entreprise du domaine de l'informatique.",
+        "Module de gestion documentaire à haut niveau de permissions et de sécurité.",
+        "Module de réservation avec gestion de plage horaire, confirmaion SMS - 2FA.",
+        "Module de gestion d'Agences et de Franchisés avec historisation et statistiques.",
+        "Module de gestion d'offres d'emploi et candidatures dans le respect des normes RGPD.",
+        "Module de carte de points d'intérêts catégoriséss avec recherche et filtres.",
+        "Module d'annuaire admistratif hiérarchisé à destination de groupes d'élus locaux.",
+        "et +"
+      ],
+      "skills": [
+        "Symfony & PHP",
+        "Doctrine & SQL",
+        "REST APIs & Mercure",
+        "NodeJs & ExpressJs",
+        "Twig & Components",
+        "VueJs",
+        "Bootstrap & SCSS",
+        "Stimulus & Turbo",
+        "UX/UI Design",
+        "CaddyServer & Nginx",
+        "Docker & Plesk",
+        "Git & GitHub",
+        "CI/CD",
+        "Agile/Scrum & Project Management"
+      ]
+    },
+    {
+      "name": "Libre Sens",
+      "position": "Développeur BackEnd - Contrat Pro.",
+      "location_type": "Sur site",
+      "location": "Agen, France",
+      "url": "https://libresens.com/",
+      "startDate": "03/10/22",
+      "endDate": "31/01/24",
+      "summary": "Concevoir et développer des fontionnalités PHP et JavaScript",
+      "responsibilities": [
+        "Supervisé en distanciel par mon tuteur pédagogique, en collaboration avec le Product Owner et l’équipe, autour de l’étude du cahier des charges, j'établis les documents de conception des applications et/ou fonctionnalités qui me sont assignés en veillant à analyser les risques et à détailler/planifier les différentes phases de livraison du MVP jusqu'au produit fini."
+      ],
+      "achievements": [
+        "Création de modules PHP/JS implémetés dans le CMS de l'entreprise.",
+        "Refonte, optimisation et sécurisation de modules existants.",
+        "Design de thèmes en fonction des maquettes fournies par le service design/intégration.",
+        "Réalisation de modules sur mesure pour implémenter des fonctionnalités spécifiques à destination des clients.",
+        "Mise en production et suivi des performances et de la sécurité.",
+        "et +"
+      ],
+      "skills": [
+        "PHP & JavaScript",
+        "REST APIs",
+        "CSS & SCSS",
+        "Git & GitHub",
+        "CI/CD",
+        "Agile/Scrum & Project Management"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "O'Clock",
+      "url": "https://oclock.io/formations/cda-alternance",
+      "area": "Centre de formation - CDA",
+      "studyType": "Titre Professionnel niveau VI RNCP31678 : Concepteur Développeur d'Applications.",
+      "startDate": "03-10-22",
+      "endDate": "01-01-24",
+      "score": "Obtenu",
+      "courses": [
+        "NodeJs / Express",
+        "Dart / Flutter",
+        "UMl / Merise / Design Patterns"
+      ]
+    },
+    {
+      "institution": "O'Clock",
+      "url": "https://oclock.io",
+      "area": "Centre de formation - DWWM",
+      "studyType": "Titre Professionnel niveau V RNCP37674 : Développeur Web et Web Mobile.",
+      "startDate": "01-07-21",
+      "endDate": "01-06-22",
+      "score": "Obtenu",
+      "courses": [
+        "Spécialisation Symfony",
+        "Html",
+        "Css",
+        "Php",
+        "Javascript"
+      ]
+    }
+  ],
+  "certificates": [
+    {
+      "name": "Titre Pro. Niveau VI - RNCP31678: Concepteur Développeur d'Applications.",
+      "date": "01-01-24",
+      "issuer": "France Compétences - Ministère du Travail",
+      "url": "https://www.francecompetences.fr/recherche/rncp/31678/"
+    },
+    {
+      "name": "Certification Opquast - Maîtrise de la qualité en projet web - Niveau Avancé",
+      "date": "15-06-22",
+      "issuer": "Opquast",
+      "url": "https://directory.opquast.com/fr/certificat/S07YEP/"
+    },
+    {
+      "name": "Titre Pro. Niveau V - RNCP37674: Développeur Web et Web Mobile.",
+      "date": "01-06-22",
+      "issuer": "France Compétences - Ministère du Travail",
+      "url": "https://www.francecompetences.fr/recherche/rncp/37674/"
+    },
+    {
+      "name": "Licence Arts-Plastiques option Infographie",
+      "date": "01-06-02",
+      "issuer": "Education Nationale",
+      "url": "https://formations.u-bordeaux-montaigne.fr/fr/catalogue-des-formations/licence-XA/licence-arts-plastiques-KQJ9IHSQ.html"
+    }
+  ],
+  "skills": [
+    {
+      "name": "..."
+    },
+    {
+      "name": "MVC",
+      "level": "Avancé",
+      "keywords": [
+        "Backend",
+        "Architecture",
+        "Design Patterns"
+      ]
+    },
+    {
+      "name": "DDD",
+      "level": "Avancé",
+      "keywords": [
+        "Backend",
+        "Architecture",
+        "Design Patterns"
+      ]
+    },
+    {
+      "name": "Clean Architecture",
+      "level": "Avancé",
+      "keywords": [
+        "Backend",
+        "Architecture",
+        "Design Patterns"
+      ]
+    },
+    {
+      "name": "Doctrine",
+      "level": "Avancé",
+      "keywords": [
+        "ORM",
+        "Backend",
+        "Symfony"
+      ]
+    },
+    {
+      "name": "Mercure",
+      "level": "Avancé",
+      "keywords": [
+        "APIs",
+        "Backend",
+        "Symfony"
+      ]
+    },
+    {
+      "name": "Messenger",
+      "level": "Autonome",
+      "keywords": [
+        "Tâches asynchrones",
+        "Backend",
+        "Messaging"
+      ]
+    },
+    {
+      "name": "JWT",
+      "level": "Autonome",
+      "keywords": [
+        "Sécurité",
+        "Authentification",
+        "Backend"
+      ]
+    },
+    {
+      "name": "Symfony Security",
+      "level": "Avancé",
+      "keywords": [
+        "Sécurité",
+        "Authentification",
+        "Backend"
+      ]
+    },
+    {
+      "name": "Nelmio Cors & Security",
+      "level": "Avancé",
+      "keywords": [
+        "Sécurité",
+        "CORS",
+        "Backend"
+      ]
+    },
+    {
+      "name": "ApiPlatform",
+      "level": "Autonome",
+      "keywords": [
+        "APIs",
+        "Backend",
+        "GraphQL",
+        "Symfony"
+      ]
+    },
+    {
+      "name": "Axios & Fetch",
+      "level": "Autonome",
+      "keywords": [
+        "API",
+        "HTTP Requests",
+        "Frontend"
+      ]
+    },
+    {
+      "name": "VueX",
+      "level": "Avancé",
+      "keywords": [
+        "State Management",
+        "Frontend",
+        "VueJs"
+      ]
+    },
+    {
+      "name": "Boostrap",
+      "level": "Avancé",
+      "keywords": [
+        "Frontend",
+        "UI",
+        "Framework"
+      ]
+    },
+    {
+      "name": "TailwindCSS",
+      "level": "Autonome",
+      "keywords": [
+        "Frontend",
+        "UI",
+        "Framework"
+      ]
+    },
+    {
+      "name": "Swiper",
+      "level": "Autonome",
+      "keywords": [
+        "Frontend",
+        "UI",
+        "Slider"
+      ]
+    },
+    {
+      "name": "EasyAdmin",
+      "level": "Avancé",
+      "keywords": [
+        "Backend",
+        "Admin Panel",
+        "Symfony"
+      ]
+    },
+    {
+      "name": "FilePond",
+      "level": "Avancé",
+      "keywords": [
+        "Gestion de fichiers",
+        "Frontend",
+        "UI"
+      ]
+    },
+    {
+      "name": "Quill",
+      "level": "Avancé",
+      "keywords": [
+        "Frontend",
+        "UI",
+        "Editor"
+      ]
+    },
+    {
+      "name": "CkEditor",
+      "level": "Avancé",
+      "keywords": [
+        "Frontend",
+        "UI",
+        "Editor"
+      ]
+    },
+    {
+      "name": "ACE Code Editor",
+      "level": "Avancé",
+      "keywords": [
+        "Frontend",
+        "UI",
+        "Editor"
+      ]
+    },
+    {
+      "name": "SSE",
+      "level": "Avancé",
+      "keywords": [
+        "APIs",
+        "Backend",
+        "Symfony"
+      ]
+    },
+    {
+      "name": "Plesk",
+      "level": "Avancé",
+      "keywords": [
+        "Serveur",
+        "Administration",
+        "Déploiement"
+      ]
+    },
+    {
+      "name": "CaddyServer",
+      "level": "Avancé",
+      "keywords": [
+        "Serveur",
+        "Administration",
+        "Déploiement"
+      ]
+    },
+    {
+      "name": "Ubuntu Server",
+      "level": "Avancé",
+      "keywords": [
+        "Serveur",
+        "Administration",
+        "Déploiement"
+      ]
+    },
+    {
+      "name": "Shell Scripting",
+      "level": "Avancé",
+      "keywords": [
+        "Automatisation",
+        "Déploiement",
+        "DevOps"
+      ]
+    },
+    {
+      "name": "Docker",
+      "level": "Avancé",
+      "keywords": [
+        "Containers",
+        "Déploiement",
+        "DevOps"
+      ]
+    },
+    {
+      "name": "GitHub Actions",
+      "level": "Autonome",
+      "keywords": [
+        "CI/CD",
+        "Déploiement",
+        "DevOps"
+      ]
+    },
+    {
+      "name": "Vitepress",
+      "level": "Autonome",
+      "keywords": [
+        "Documentation",
+        "Frontend",
+        "Static Site Generator"
+      ]
+    },
+    {
+      "name": "Castor",
+      "level": "Autonome",
+      "keywords": [
+        "Formulaires",
+        "Symfony",
+        "Backend"
+      ]
+    },
+    {
+      "name": "Passport",
+      "level": "Avancé",
+      "keywords": [
+        "Authentification",
+        "Backend",
+        "NodeJs"
+      ]
+    },
+    {
+      "name": "Sequelize",
+      "level": "Avancé",
+      "keywords": [
+        "ORM",
+        "Backend",
+        "NodeJs"
+      ]
+    },
+    {
+      "name": "VueJs",
+      "level": "Autonome",
+      "keywords": [
+        "Frontend",
+        "JavaScript Framework"
+      ]
+    },
+    {
+      "name": "WebPack",
+      "level": "Avancé",
+      "keywords": [
+        "Frontend",
+        "Bundler",
+        "Assets"
+      ]
+    },
+    {
+      "name": "..."
+    }
+  ],
+  "languages": [
+    {
+      "language": "Anglais",
+      "fluency": "Niveau professionnel"
+    },
+    {
+      "language": "Espagnol",
+      "fluency": "Niveau professionnel"
+    }
+  ],
+  "interests": [
+    {
+      "name": "Technology",
+      "keywords": [
+        "AI",
+        "Machine Learning",
+        "Web Development",
+        "Open Source"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "name": "",
+      "reference": ""
+    }
+  ],
+  "projects": [
+    {
+      "name": "Ch***Con***",
+      "isActive": false,
+      "description": "Réalisé en Entreprise, cette application web est un outil de gestion pour une Entreprise du domaine de l'Informatique.",
+      "highlights": [
+        "Gestion des Contacts et des Entreprises",
+        "Gestion des Produits et des Catégories (hiérarchie Doctrine Tree)",
+        "Gestion des Commandes clients - Workflow d'états",
+        "Gestion des prise en charge de matériel pour réparation - Workflow d'états",
+        "Gestion des interventions techniques - Workflow d'états",
+        "Gestion abonnements et des paiements",
+        "Gestion asynchrone d'envoie SMS instantanées + 1h + 4h",
+        "Gestion de création de .pdf et de QRCode",
+        "Historisation des actions et des modifications",
+        "Automatisation des tâches récurrentes",
+        "Geston avancée de la sécurité et des autorisations",
+        "Optimisation de l'accès aux données avec des query DTO",
+        "Mise en place d'un OCR pour la reconnaissance de texte des documents scannés",
+        "Sécurité et optimisation des performances",
+        "..."
+      ],
+      "url": "https://ergo-up.fr/"
+    },
+    {
+      "name": "Ergo-Up",
+      "isActive": true,
+      "description": "Implementée au coeur du CMS de l'entreprise dans le cadre de mon contrat de professionnalisation, ce projet est une application web de gestion et de suivi d'autonomie des résidents en EHPAD ",
+      "highlights": [
+        "Gestion des établissement, des soigants et des résidents",
+        "Gestion et administration du test de santé pour les résidents",
+        "Gestion de l'évaluation des soins et du personnel requis en fonction des résulats des tests",
+        "Gestion des équipements médicaux et personnel requis en fonction des résulats des tests",
+        "Gestion de la durée de validités des résultats des tests",
+        "Gestion des valeurs de retour en fonciton des caractéristiques des résidents",
+        "Gestion de l'achat de test pour les particuliers, crédits et historique",
+        "Statistiques et rapports sur les résultats des tests, du personnel et des équipements requis",
+        "Historisation du suivi des statistiques et des rapports",
+        "..."
+      ],
+      "url": "https://ergo-up.fr/"
+    },
+    {
+      "name": "Publisher SPA",
+      "isActive": false,
+      "description": "Une SPA de publication de contenu de type articles, réalisée dans le cadre de recherches personnelles pour approfondir mes compétences avec Node.js et Express.js.",
+      "highlights": [
+        "Gestion de l'authentification et de la session en utilisant Passport.js",
+        "Utilisation du pattern Clean Architecture et organisation du code en couches à responsabilités uniques",
+        "Séparation entre le FrontEnd Vue.js et le BackEnd Express.js",
+        "Utilisation de l'ORM Sequelize pour la gestion des données",
+        "Gestion et utilisation de JWT pour les autorisations",
+        "Utilisation de Mercure pour les mises à jour en temps réel - SSE",
+        "Gestion de notifications par email",
+        "Configuration de Quill pour l'édition de contenu riche",
+        "..."
+      ],
+      "github": "https://github.com/SimonChabrier/ressourceManager"
+    },
+    {
+      "name": "Task Runner",
+      "isActive": false,
+      "description": "Réalisé dans le cadre de recherches personnelles pour cloner, initialiser et lancer un projet Symfony en une seule commande : castor new-project.",
+      "highlights": [
+        "Clone le repository depuis GitHub",
+        "Demande l'url ou le ssh du repository",
+        "Configuration de l'environnement de développement",
+        "Intallation des dépendances composer",
+        "Intallation des dépendances npm si un package.json est présent",
+        "Configuration de la base de données avec choix du driver",
+        "Création du .env.local à partir du .env",
+        "Injection du schema de base de données",
+        "Lancement du serveur de développement",
+        "Lancement du serveur pour monitorer les assets",
+        "Ouverture du navigateur par défaut",
+        "A la fin du run le projet est prêt à être développé",
+        "Messages confirmation à chaque étape",
+        "..."
+      ],
+      "github": "https://github.com/SimonChabrier/CastorCloneToRun"
+    },
+    {
+      "name": "Eco-Conception SPA",
+      "isActive": true,
+      "description": "Une application web qui référence 50 règles d'éco-conception web, réalisé dans le cadre de recherches personnelles pour approfondir mes compétences avec VueJs pour le fornt et Symfony pour l'API REST.",
+      "highlights": [
+        "Filtre de recherche textuel et par Tags",
+        "Gestion d'une pagination dynamique",
+        "Developpement d'un bibiilothèque de composants réutilisables",
+        "Configuration l'environnement VueJs au coeur de Symfony",
+        "Configuration de Webpack pour la compilation des assets",
+        "Création d'une API REST légère et performante",
+        "Utilisation de Pinia pour la gestion des états"
+      ],
+      "url": "https://ecoconception.simschab.cloud/#/api",
+      "github": "https://github.com/SimonChabrier/EcoConcept-Symfony5.4-VueJs3"
+    },
+    {
+      "name": "Utimate Todo's",
+      "isActive": true,
+      "description": "Réalisé dans le cadre de recherches personnelles pour gérer mes tâches de développement dans une interfce correspondant à mes besois.",
+      "highlights": [
+        "Back-end Symfony pour exposer une API REST",
+        "Front-end Javascript vanilla pour consommer l'API dans un environnement SPA léger",
+        "Drag and drop pour organiser les tâches",
+        "Gestion des positions des tâches dans les colonnes",
+        "Gestion des statuts et de l'ordre des tâches",
+        "Création à la volée de nouvelles tâches et de nouvelles colonnes",
+        "Sauvegarde automatisée de l'état de l'UI",
+        "Autorisation par token JWT"
+      ],
+      "url": "https://js.simschab.cloud/trello/",
+      "github": "https://github.com/SimonChabrier/Trello-Front-End"
+    },
+    {
+      "name": "Concept Store",
+      "isActive": true,
+      "description": "Réalisé avec Symfony et Javascript dans le cadre de mes recherches personnelles, ce projet est une application web e-commerce classique et pleinement fonctionnelle.",
+      "highlights": [
+        "Gestion complète du catalogue de produits",
+        "Gestion des catégories et des sous-catégories",
+        "Filtres de recherche par critères cumulables sans rechargement de page",
+        "Intégration de paiement sécurisé - Stripe",
+        "Gestion du panier d'achat en session et en persistance",
+        "Gestion des stocks et des commandes",
+        "Gestion du cache, tant que le contenu du catalogue produit n'a pas changé on ne refait pas de requête SQL",
+        "..."
+      ],
+      "url": "https://storeproject.simschab.cloud/",
+      "github": "https://github.com/SimonChabrier/StoreProject"
+    },
+    {
+      "name": "Utimate Doc's",
+      "isActive": true,
+      "description": "J'utilise VitePress pour documenter les projets réalisés dans le cadre professionnel et personnel.",
+      "highlights": [
+        "Sur ma documentation personnelle j'ai ajouté des fonctionnalités spécifiques pour répondre à mes besoins",
+        "3 domaines différent pointent vers la même instance de la documentation",
+        "Injection dynamique du script de suivi Matomo en fonction du domaine",
+        "Injection dynamique d'url canonical en fonction du domaine",
+        "Auto-hébergement sur mon serveur Ubuntu",
+        "Suivi Matomo auto-hébergé aussi sur mon serveur",
+        "..."
+      ],
+      "url": "https://doc.simschab.cloud/",
+      "github": "https://github.com/SimonChabrier/MesDocs"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "build": "astro check && astro build --mode production",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "translate-cv": "node scripts/translate-cv.mjs"
   },
   "dependencies": {
     "@alpinejs/collapse": "^3.14.9",

--- a/scripts/translate-cv.mjs
+++ b/scripts/translate-cv.mjs
@@ -1,0 +1,60 @@
+import fs from 'fs/promises';
+import fetch from 'node-fetch';
+
+const API_URL = process.env.TRANSLATION_API_URL || 'https://traduction.simschab.cloud/translate';
+const API_KEY = process.env.TRANSLATION_API_KEY || 'b5d889f372d98a0c5ebfc07f972c3cbb';
+
+async function translateText(text, source = 'fr', target = 'en') {
+  const payload = {
+    q: text,
+    source,
+    target,
+    format: 'html',
+    alternatives: 1,
+    secret: '',
+  };
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`Translation failed: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.translatedText || text;
+}
+
+async function translateObject(obj) {
+  if (Array.isArray(obj)) {
+    const arr = [];
+    for (const val of obj) arr.push(await translateObject(val));
+    return arr;
+  }
+  if (obj && typeof obj === 'object') {
+    const result = {};
+    for (const [k, v] of Object.entries(obj)) {
+      result[k] = await translateObject(v);
+    }
+    return result;
+  }
+  if (typeof obj === 'string') {
+    return await translateText(obj);
+  }
+  return obj;
+}
+
+async function main() {
+  const frData = JSON.parse(await fs.readFile('cv.json', 'utf8'));
+  const enData = await translateObject(frData);
+  await fs.writeFile('cv.en.json', JSON.stringify(enData, null, 2));
+  console.log('English CV updated');
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/components/KeyboardManager.astro
+++ b/src/components/KeyboardManager.astro
@@ -2,8 +2,11 @@
 import "hotkeypad/reset.css";
 import "hotkeypad/index.css";
 import { type SocialIcon } from "@/types";
-import { basics } from "@cv";
+interface Props {
+  basics: any;
+}
 
+const { basics } = Astro.props as Props;
 const { profiles } = basics;
 
 const SOCIAL_ICONS: SocialIcon = {

--- a/src/components/LanguageSwitch.astro
+++ b/src/components/LanguageSwitch.astro
@@ -1,0 +1,34 @@
+---
+const { lang = 'fr' } = Astro.props;
+---
+<div class="no-print inline-flex items-center">
+  <label for="languageSwitch" class="sr-only">Choisir la langue</label>
+  <select id="languageSwitch" name="languageSwitch" class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-skin-base ring-1 ring-inset ring-skin-muted focus:ring-2 focus:ring-skin-hue dark:text-white sm:text-sm sm:leading-6">
+    <option value="fr" class="dark:text-white">Français</option>
+    <option value="en" class="dark:text-white">English</option>
+  </select>
+
+  <script>
+    const select = document.getElementById('languageSwitch');
+    const saved = localStorage.getItem('lang');
+    const pathLang = window.location.pathname.startsWith('/en') ? 'en' : 'fr';
+    const current = saved || pathLang;
+    select.value = current;
+    if (saved && saved !== pathLang) {
+      if (saved === 'en') {
+        window.location.pathname = '/en/';
+      } else {
+        window.location.pathname = '/';
+      }
+    }
+    select.addEventListener('change', () => {
+      const value = select.value;
+      localStorage.setItem('lang', value);
+      if (value === 'en') {
+        window.location.pathname = '/en/';
+      } else {
+        window.location.pathname = '/';
+      }
+    });
+  </script>
+</div>

--- a/src/components/sections/About.astro
+++ b/src/components/sections/About.astro
@@ -1,11 +1,15 @@
 ---
 import Section from "../Section.astro";
 
-import { basics } from "@cv";
-const { summary } = basics;
+interface Props {
+  summary: string;
+  lang?: string;
+}
+
+const { summary, lang = 'fr' } = Astro.props as Props;
 ---
 
-<Section title="A propos">
+<Section title={lang === 'fr' ? 'A propos' : 'About'}>
 	<p>
 		{summary}
 	</p>

--- a/src/components/sections/Education.astro
+++ b/src/components/sections/Education.astro
@@ -1,11 +1,17 @@
 ---
 import Section from "../Section.astro";
 
-import { education } from "@cv";
-import { certificates } from "@cv";
+interface Props {
+  education: any[];
+  certificates: any[];
+  lang?: string;
+  className?: string;
+}
+
+const { education, certificates, lang = 'fr' } = Astro.props as Props;
 ---
 
-<Section className={Astro.props.className} title="Formations">
+<Section className={Astro.props.className} title={lang === 'fr' ? 'Formations' : 'Education'}>
 	<ul class="space-y-4 py-3 print:space-y-0">
 		{
 			education.map(({ institution, startDate, endDate, area, url }) => {
@@ -44,7 +50,7 @@ import { certificates } from "@cv";
 	{
 		certificates.length > 0 && (
 			<>
-				<h4>Diplômes et Certifications</h4>
+                                <h4>{lang === 'fr' ? 'Diplômes et Certifications' : 'Degrees & Certifications'}</h4>
 				<ul class="space-y-4 py-3 print:space-y-0">
 					{certificates.map(({ name, date, issuer, url }) => {
 						const certificateYear = new Date(date).getFullYear();

--- a/src/components/sections/Experience.astro
+++ b/src/components/sections/Experience.astro
@@ -1,6 +1,12 @@
 ---
 import Section from "../Section.astro"
-import { work } from "@cv"
+interface Props {
+  work: any[];
+  lang?: string;
+  className?: string;
+}
+
+const { work, lang = 'fr' } = Astro.props as Props
 
 import HTML from "@/icons/html.astro"
 import CSS from "@/icons/css.astro"
@@ -37,7 +43,7 @@ const SKILLS_ICONS: Record<string, any> = {
 }
 
 ---
-<Section className={Astro.props.className} title="Expérience" id="experience">
+<Section className={Astro.props.className} title={lang === 'fr' ? 'Expérience' : 'Experience'} id="experience">
   <ul class="flex flex-col">
     {work.map(({ name, startDate, endDate, position, summary, responsibilities, achievements, url, skills, location, location_type }) => {
       // const startYear = new Date(startDate).getFullYear()
@@ -84,7 +90,7 @@ const SKILLS_ICONS: Record<string, any> = {
               <div class="mt-4  print:gap-0 flex flex-col gap-4 print:text-xs text-sm" x-data="{ expanded: false }">
                 {summary && (
                   <div class="flex flex-col gap-1">
-                    <h4>Missions:</h4>
+                    <h4>{lang === 'fr' ? 'Missions:' : 'Missions:'}</h4>
                     <ul class="text-skin-muted [&>li]:ml-4 flex list-disc flex-col gap-2">
                       {Array.isArray(summary) ? (
                         summary.map(item => (
@@ -101,7 +107,7 @@ const SKILLS_ICONS: Record<string, any> = {
                 <div class="md:after:from-skin-hue dark:md:after:to-skin-hue/0  flex relative flex-col max-sm:!h-auto print:!h-auto gap-4 print:gap-2 md:after:bg-gradient-to-t md:after:absolute md:after:bottom-0 md:after:w-full print:after:hidden md:after:h-12 md:after:content-[''] " :class="expanded ? 'after:hidden' : ''" x-show="expanded">
                 {responsibilities && (
                   <div class="flex flex-col gap-1">
-                    <h4>Responsabilités:</h4>
+                    <h4>{lang === 'fr' ? 'Responsabilités:' : 'Responsibilities:'}</h4>
                     <ul class="text-skin-muted [&>li]:ml-4 flex list-disc flex-col gap-2">
                       {responsibilities.map(responsibility => (
                         <li>{responsibility}</li>
@@ -112,7 +118,7 @@ const SKILLS_ICONS: Record<string, any> = {
 
                 {achievements && (
                   <div class="flex flex-col gap-1">
-                    <h4>Réalisations:</h4>
+                    <h4>{lang === 'fr' ? 'Réalisations:' : 'Achievements:'}</h4>
                     <ul class="text-skin-muted [&>li]:ml-4 flex list-disc flex-col gap-2">
                       {achievements.map(achievement => (
                         <li>{achievement}</li>
@@ -123,12 +129,12 @@ const SKILLS_ICONS: Record<string, any> = {
                 </div>
                 
                 <button @click="expanded = ! expanded" class="print:hidden group/more w-fit cursor-pointer items-center justify-center gap-1.5 text-xs underline text-skin-link/100 transition-all hover:text-skin-base flex">
-                  <span x-text="expanded ? 'Voir moins' : 'Voir plus'">Voir plus</span>
+                  <span x-text="expanded ? (lang === 'fr' ? 'Voir moins' : 'Show less') : (lang === 'fr' ? 'Voir plus' : 'Show more')">{lang === 'fr' ? 'Voir plus' : 'Show more'}</span>
                   <svg class="w-4 h-4 group-hover/more:translate-y-0.5 duration-200 ease-out" :class="{ 'rotate-180': expanded }" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
                 </button>
 
 
-                <ul class="flex print:hidden flex-wrap gap-2" aria-label="Technologies utilisées">
+                <ul class="flex print:hidden flex-wrap gap-2" aria-label={lang === 'fr' ? 'Technologies utilisées' : 'Used technologies'}>
                   {skills && skills.map(skill => {
                     const iconName = skill === "Next.js" ? "Next" : skill
                     const Icon = SKILLS_ICONS[iconName]

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -1,5 +1,10 @@
 ---
-import { basics } from "@cv";
+interface Props {
+  basics: any;
+  lang?: string;
+}
+
+const { basics, lang = 'fr' } = Astro.props as Props;
 import Section from "@/components/Section.astro";
 import Mail from "@/icons/Mail.astro";
 import Phone from "@/icons/Phone.astro";

--- a/src/components/sections/Projects.astro
+++ b/src/components/sections/Projects.astro
@@ -3,11 +3,17 @@ import Git from "@/icons/git.astro";
 import Arrow from "@/icons/Arrow.astro";
 import Section from "../Section.astro";
 
-import { projects } from "@cv";
+interface Props {
+  projects: any[];
+  lang?: string;
+  className?: string;
+}
+
+const { projects, lang = 'fr' } = Astro.props as Props;
 ---
 
-<Section className={Astro.props.className} title="Réalisations" id="projects">
-	<span class="text-skin-muted" style="font-size: 14px;">Quelques projets représentatifs de ces deux dernières années...</span>
+<Section className={Astro.props.className} title={lang === 'fr' ? 'Réalisations' : 'Projects'} id="projects">
+        <span class="text-skin-muted" style="font-size: 14px;">{lang === 'fr' ? 'Quelques projets représentatifs de ces deux dernières années...' : 'Some representative projects from the last two years...'}</span>
 	<div class="grid grid-cols-1 gap-3 md:grid-cols-2 print:flex print:flex-col">
 		{
 			projects.map(({ url, description, highlights, name, isActive, github }) => {

--- a/src/components/sections/Skills.astro
+++ b/src/components/sections/Skills.astro
@@ -11,7 +11,13 @@ import Section from "../Section.astro";
 // import GitHub from "@/icons/GitHub.astro";
 // import Tailwind from "@/icons/tailwind.astro";
 // import Next from "@/icons/next.astro";
-import { skills } from "@cv";
+interface Props {
+  skills: any[];
+  lang?: string;
+  className?: string;
+}
+
+const { skills, lang = 'fr' } = Astro.props as Props;
 // import Swift from "@/icons/swift.astro";
 // import SwiftUI from "@/icons/swiftui.astro";
 // import Kotlin from "@/icons/kotlin.astro";
@@ -40,7 +46,7 @@ import { skills } from "@cv";
 // };
 ---
 
-<Section className={Astro.props.className} title="Technologies">
+<Section className={Astro.props.className} title={lang === 'fr' ? 'Technologies' : 'Skills'}>
         <ul class="[&>li>svg]:text-skin-hue inline-flex flex-wrap gap-6 [&>li>svg]:size-5 [&>li]:text-sm">
                 {
                         skills.map(({ name, level, keywords }) => {

--- a/src/components/sections/Skills.astro
+++ b/src/components/sections/Skills.astro
@@ -83,7 +83,7 @@ const { skills, lang = 'fr' } = Astro.props as Props;
                                                 >
                                                         <div class="font-semibold">Niveau : {level}</div>
                                                         <ul class="mt-1 flex flex-wrap gap-1">
-                                                                {keywords?.map(keyword => (
+                                                                {keywords?.map((keyword: string) => (
                                                                         <li class="rounded bg-skin-button-muted px-1 dark:bg-gray-700">{keyword}</li>
                                                                 ))}
                                                         </ul>

--- a/src/components/sections/Tail.astro
+++ b/src/components/sections/Tail.astro
@@ -1,6 +1,12 @@
 ---
-import { basics } from "@cv";
 import Dialog from "@/components/Dialog.astro";
+
+interface Props {
+  basics: any;
+  lang?: string;
+}
+
+const { basics, lang = 'fr' } = Astro.props as Props;
 const { name, profiles } = basics;
 
 const gitHub = profiles.find(({ network }) => network === "GitHub");

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,18 +1,18 @@
 ---
-import { basics } from "@cv";
-
 interface Props {
-	title: string;
+  title: string;
+  lang?: string;
+  basics: any;
 }
 
-const { title } = Astro.props;
+const { title, lang = 'fr', basics } = Astro.props as Props;
 const { image, summary, theme } = basics;
 const canonical = Astro.url.href;
 const canonicalDomain = Astro.url.origin;
 ---
 
 <!doctype html>
-<html lang="fr">
+<html lang={lang}>
 	<head>
 		<meta charset="UTF-8" />
 		<title>{title}</title>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -12,26 +12,26 @@ import KeyboardManager from "@/components/KeyboardManager.astro";
 import ThemeSwitch from "@/components/ThemeSwitch.astro";
 import LanguageSwitch from "@/components/LanguageSwitch.astro";
 
-import cv from "@cv";
+import cv from "@cv-en";
 const { basics } = cv;
 const { name, label } = basics;
 ---
 
-<Layout title={`${name} - ${label}`} lang="fr" basics={cv.basics}>
+<Layout title={`${name} - ${label}`} lang="en" basics={cv.basics}>
 	<main class="relative grid max-w-7xl gap-12 p-8 max-sm:py-16 md:grid-cols-6 md:p-16 xl:gap-24 print:max-w-none print:grid-cols-1 print:gap-6">
 		<div class="space-y-6 md:col-span-2 print:col-span-1 print:grid print:grid-cols-2 print:gap-5 print:space-y-0">
-                        <Hero basics={cv.basics} lang="fr" />
-                        <About summary={cv.basics.summary} lang="fr" />
+                        <Hero basics={cv.basics} lang="en" />
+                        <About summary={cv.basics.summary} lang="en" />
                         <ThemeSwitch />
                         <LanguageSwitch />
 		</div>
 		<div class="space-y-12 md:col-span-4 print:col-span-1 print:grid print:grid-cols-4 print:gap-2 print:space-y-0">
-                        <Experience work={cv.work} className="print:col-span-3" lang="fr" />
-                        <Projects projects={cv.projects} className="print:hidden" lang="fr" />
-                        <Skills skills={cv.skills} className="print:hidden" lang="fr" />
-                        <Education education={cv.education} certificates={cv.certificates} className="order-first" lang="fr" />
+                        <Experience work={cv.work} className="print:col-span-3" lang="en" />
+                        <Projects projects={cv.projects} className="print:hidden" lang="en" />
+                        <Skills skills={cv.skills} className="print:hidden" lang="en" />
+                        <Education education={cv.education} certificates={cv.certificates} className="order-first" lang="en" />
                 </div>
-                <Tail basics={cv.basics} lang="fr" />
+                <Tail basics={cv.basics} lang="en" />
 
 	</main>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "paths": {
       "@cv": ["./cv.json"],
       "@mentions": ["./mentions.json"],
+      "@cv-en": ["./cv.en.json"],
       "@/*": ["src/*"]
     }
   },


### PR DESCRIPTION
## Summary
- add script to translate `cv.json` using external API
- create GitHub workflow to auto-update `cv.en.json`
- add language switch component and English pages
- pass CV data as props for components
- allow dynamic language in layout and sections

## Testing
- `pnpm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868ddeca9a0832a80e9b46244583f6b