### PR TITLE
Add language toggle

### DIFF
--- a/src/components/LanguageSwitch.astro
+++ b/src/components/LanguageSwitch.astro
@@ -1,0 +1,52 @@
+---
+import FlagFR from "@/icons/FlagFR.astro"
+import FlagEN from "@/icons/FlagEN.astro"
+interface Props {
+  lang?: string;
+}
+const { lang = 'fr' } = Astro.props as Props
+---
+<div class="no-print flex items-center">
+  <div class="group/lang flex items-center gap-2">
+    <label for="languageSwitch" aria-label="Changer la langue" class="flex items-center gap-1 text-sm font-medium leading-6 text-skin-base">
+      <span class="flag-fr" style="display:{lang === 'fr' ? 'inline-block' : 'none'}"><FlagFR /></span>
+      <span class="flag-en" style="display:{lang === 'en' ? 'inline-block' : 'none'}"><FlagEN /></span>
+      <span class="sr-only">Changer la langue</span>
+    </label>
+    <select id="languageSwitch" name="languageSwitch" class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-skin-base ring-1 ring-inset ring-skin-muted focus:ring-2 focus:ring-skin-hue dark:text-white sm:text-sm sm:leading-6">
+      <option value="fr" class="dark:text-white">Français</option>
+      <option value="en" class="dark:text-white">English</option>
+    </select>
+  </div>
+  <style>
+    .dark select option { color: white !important; }
+  </style>
+  <script>
+    const select = document.getElementById('languageSwitch');
+    const frIcon = document.querySelector('.flag-fr');
+    const enIcon = document.querySelector('.flag-en');
+    const stored = localStorage.getItem('lang') || '{lang}';
+    select.value = stored;
+    updateIcon(stored);
+    function updateIcon(value){
+      if(value === 'fr'){
+        frIcon.style.display = 'inline-block';
+        enIcon.style.display = 'none';
+      } else {
+        enIcon.style.display = 'inline-block';
+        frIcon.style.display = 'none';
+      }
+    }
+    function updateLang(value){
+      localStorage.setItem('lang', value);
+      const url = new URL(window.location.href);
+      url.searchParams.set('lang', value);
+      window.location.href = url.toString();
+    }
+    select.addEventListener('change', (e)=>{
+      const value = e.target.value;
+      updateIcon(value);
+      updateLang(value);
+    });
+  </script>
+</div>

--- a/src/components/LanguageSwitch.astro
+++ b/src/components/LanguageSwitch.astro
@@ -25,7 +25,7 @@ const { lang = 'fr' } = Astro.props as Props
     const select = document.getElementById('languageSwitch');
     const frIcon = document.querySelector('.flag-fr');
     const enIcon = document.querySelector('.flag-en');
-    const stored = localStorage.getItem('lang') || '{lang}';
+    const stored = localStorage.getItem('lang') || "${lang}";
     select.value = stored;
     updateIcon(stored);
     function updateIcon(value){

--- a/src/components/ThemeSwitch.astro
+++ b/src/components/ThemeSwitch.astro
@@ -2,7 +2,7 @@
 import Theme from "@/icons/themeSwitch.astro";
 ---
 
-<div class="no-print inline-flex items-center">
+<div class="no-print flex items-center">
   <div class="group/theme flex items-center gap-2">
     <label
       for="themeSwitch"

--- a/src/components/sections/Experience.astro
+++ b/src/components/sections/Experience.astro
@@ -2,6 +2,13 @@
 import Section from "../Section.astro"
 import { work } from "@cv"
 
+interface Props {
+  lang?: string;
+  className?: string;
+}
+
+const { lang = 'fr' } = Astro.props as Props
+
 import HTML from "@/icons/html.astro"
 import CSS from "@/icons/css.astro"
 import JavaScript from "@/icons/javascript.astro"
@@ -37,7 +44,7 @@ const SKILLS_ICONS: Record<string, any> = {
 }
 
 ---
-<Section className={Astro.props.className} title="Expérience" id="experience">
+<Section className={Astro.props.className} title={lang === 'fr' ? 'Expérience' : 'Experience'} id="experience">
   <ul class="flex flex-col">
     {work.map(({ name, startDate, endDate, position, summary, responsibilities, achievements, url, skills, location, location_type }) => {
       // const startYear = new Date(startDate).getFullYear()
@@ -47,7 +54,7 @@ const SKILLS_ICONS: Record<string, any> = {
         <li class="relative print:py-2">
           <div class="group relative grid pb-1 print:pb-0 transition-all print:grid-cols-1 print:gap-1 sm:grid-cols-12 sm:gap-8 md:gap-6 lg:hover:!opacity-100 ">
             <header class="relative mt-1 text-xs font-semibold sm:col-span-2">
-              <time datetime={startDate} data-title={startDate}>{startDate}</time> - <time datetime={endDate} data-title={endDate}>{endDate ?? "Actuel"}</time>
+              <time datetime={startDate} data-title={startDate}>{startDate}</time> - <time datetime={endDate} data-title={endDate}>{endDate ?? (lang === 'fr' ? 'Actuel' : 'Current')}</time>
             </header>
             <div class="relative flex flex-col pb-6 print:pb-0 before:-ml-6 sm:col-span-10 before:w-px print:before:hidden before:absolute before:bg-skin-muted before:h-full before:mt-2">
               {/* petits ronds de l'historique */}
@@ -81,10 +88,10 @@ const SKILLS_ICONS: Record<string, any> = {
                   {location} {location && location_type && '-'} {location_type}
                 </div>
               )}
-              <div class="mt-4  print:gap-0 flex flex-col gap-4 print:text-xs text-sm" x-data="{ expanded: false }">
+              <div class="mt-4  print:gap-0 flex flex-col gap-4 print:text-xs text-sm" x-data=`{ expanded: false, lang: '${lang}' }`>
                 {summary && (
                   <div class="flex flex-col gap-1">
-                    <h4>Missions:</h4>
+                    <h4>{lang === 'fr' ? 'Missions:' : 'Missions:'}</h4>
                     <ul class="text-skin-muted [&>li]:ml-4 flex list-disc flex-col gap-2">
                       {Array.isArray(summary) ? (
                         summary.map(item => (
@@ -101,7 +108,7 @@ const SKILLS_ICONS: Record<string, any> = {
                 <div class="md:after:from-skin-hue dark:md:after:to-skin-hue/0  flex relative flex-col max-sm:!h-auto print:!h-auto gap-4 print:gap-2 md:after:bg-gradient-to-t md:after:absolute md:after:bottom-0 md:after:w-full print:after:hidden md:after:h-12 md:after:content-[''] " :class="expanded ? 'after:hidden' : ''" x-show="expanded">
                 {responsibilities && (
                   <div class="flex flex-col gap-1">
-                    <h4>Responsabilités:</h4>
+                    <h4>{lang === 'fr' ? 'Responsabilités:' : 'Responsibilities:'}</h4>
                     <ul class="text-skin-muted [&>li]:ml-4 flex list-disc flex-col gap-2">
                       {responsibilities.map(responsibility => (
                         <li>{responsibility}</li>
@@ -112,7 +119,7 @@ const SKILLS_ICONS: Record<string, any> = {
 
                 {achievements && (
                   <div class="flex flex-col gap-1">
-                    <h4>Réalisations:</h4>
+                    <h4>{lang === 'fr' ? 'Réalisations:' : 'Achievements:'}</h4>
                     <ul class="text-skin-muted [&>li]:ml-4 flex list-disc flex-col gap-2">
                       {achievements.map(achievement => (
                         <li>{achievement}</li>
@@ -123,12 +130,12 @@ const SKILLS_ICONS: Record<string, any> = {
                 </div>
                 
                 <button @click="expanded = ! expanded" class="print:hidden group/more w-fit cursor-pointer items-center justify-center gap-1.5 text-xs underline text-skin-link/100 transition-all hover:text-skin-base flex">
-                  <span x-text="expanded ? 'Voir moins' : 'Voir plus'">Voir plus</span>
+                  <span x-text="expanded ? (lang === 'fr' ? 'Voir moins' : 'Show less') : (lang === 'fr' ? 'Voir plus' : 'Show more')">{lang === 'fr' ? 'Voir plus' : 'Show more'}</span>
                   <svg class="w-4 h-4 group-hover/more:translate-y-0.5 duration-200 ease-out" :class="{ 'rotate-180': expanded }" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
                 </button>
 
 
-                <ul class="flex print:hidden flex-wrap gap-2" aria-label="Technologies utilisées">
+                <ul class="flex print:hidden flex-wrap gap-2" aria-label={lang === 'fr' ? 'Technologies utilisées' : 'Used technologies'}>
                   {skills && skills.map(skill => {
                     const iconName = skill === "Next.js" ? "Next" : skill
                     const Icon = SKILLS_ICONS[iconName]

--- a/src/icons/FlagEN.astro
+++ b/src/icons/FlagEN.astro
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="16" viewBox="0 0 60 30">
+  <clipPath id="t"><path d="M0 0v30h60V0z"/></clipPath>
+  <clipPath id="s"><path d="M0 0l60 30M60 0L0 30"/></clipPath>
+  <g clip-path="url(#t)">
+    <path d="M0 0h60v30H0z" fill="#012169"/>
+    <path d="M0 0l60 30M60 0L0 30" stroke="#fff" stroke-width="6"/>
+    <path d="M0 0l60 30M60 0L0 30" stroke="#C8102E" stroke-width="4" clip-path="url(#s)"/>
+    <path d="M30 0v30M0 15h60" stroke="#fff" stroke-width="10"/>
+    <path d="M30 0v30M0 15h60" stroke="#C8102E" stroke-width="6"/>
+  </g>
+</svg>

--- a/src/icons/FlagFR.astro
+++ b/src/icons/FlagFR.astro
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="16" viewBox="0 0 3 2">
+  <rect width="1" height="2" fill="#002395" />
+  <rect width="1" height="2" x="1" fill="#ffffff" />
+  <rect width="1" height="2" x="2" fill="#ED2939" />
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,20 +10,26 @@ import Skills from "@/components/sections/Skills.astro";
 import Tail from "@/components/sections/Tail.astro";
 import KeyboardManager from "@/components/KeyboardManager.astro";
 import ThemeSwitch from "@/components/ThemeSwitch.astro";
+import LanguageSwitch from "@/components/LanguageSwitch.astro";
 
 import { basics } from "@cv";
 const { name, label } = basics;
+const langParam = Astro.url.searchParams.get('lang');
+const lang = langParam === 'en' ? 'en' : 'fr';
 ---
 
 <Layout title={`${name} - ${label}`}>
 	<main class="relative grid max-w-7xl gap-12 p-8 max-sm:py-16 md:grid-cols-6 md:p-16 xl:gap-24 print:max-w-none print:grid-cols-1 print:gap-6">
-		<div class="space-y-6 md:col-span-2 print:col-span-1 print:grid print:grid-cols-2 print:gap-5 print:space-y-0">
-			<Hero />
-			<About />
-			<ThemeSwitch />
-		</div>
+                <div class="space-y-6 md:col-span-2 print:col-span-1 print:grid print:grid-cols-2 print:gap-5 print:space-y-0">
+                        <Hero />
+                        <About />
+                        <div class="flex flex-col gap-2">
+                                <ThemeSwitch />
+                                <LanguageSwitch lang={lang} />
+                        </div>
+                </div>
 		<div class="space-y-12 md:col-span-4 print:col-span-1 print:grid print:grid-cols-4 print:gap-2 print:space-y-0">
-			<Experience className="print:col-span-3" />
+                        <Experience className="print:col-span-3" lang={lang} />
 			<Projects className="print:hidden" />
 			<Skills className="print:hidden" />
 			<Education className="order-first" />


### PR DESCRIPTION
## Summary
- add a LanguageSwitch component with flag icons
- adjust ThemeSwitch layout for vertical stacking
- translate Experience section texts
- pass language selection down from the index page

## Testing
- `pnpm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_686917c7e488832ab5c61976ac56aabf